### PR TITLE
fixed README error of autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -100,6 +100,12 @@ clean-local:
 maintainer-clean-local:
 	rm -rf doxygen
 
+# We are using a README.md and not a README file. However, autotools forces us
+# to use a README file. With this rule, we trick autotools in thinking that we
+# provide a README.
+README: README.md
+	pandoc -f markdown -t plain --wrap=none $< -o $@
+
 doxygen: Doxyfile
 	doxygen
 


### PR DESCRIPTION
Autotools expects a `README` file, but t8dg has a `README.md` file. This fixes the error.